### PR TITLE
Fix examples run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Examples
 #
 
+realm := $(or ${realm},${realm},test1)
+
 examples: \
 	ex_status \
 	ex_list_nodes \
@@ -19,46 +21,46 @@ examples: \
 	ex_docker
 
 ex_status:
-	python -u examples/ex_status.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_status.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_list_nodes:
-	python -u examples/ex_list_nodes.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_list_nodes.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_list_workers:
-	python -u examples/ex_list_workers.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_list_workers.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_start_router:
-	python -u examples/ex_start_router.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_start_router.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_start_proxy:
-	python -u examples/ex_start_proxy.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_start_proxy.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_start_container:
-	python -u examples/ex_start_container.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_start_container.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_start_guest:
-	python -u examples/ex_start_guest.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_start_guest.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_list_sessions:
-	python -u examples/ex_list_sessions.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_list_sessions.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_list_subs_regs:
-	python -u examples/ex_list_subs_regs.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_list_subs_regs.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_cpu_affinity:
-	python -u examples/ex_cpu_affinity.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_cpu_affinity.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_process_stats:
-	python -u examples/ex_process_stats.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_process_stats.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_worker_log:
-	python -u examples/ex_worker_log.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_worker_log.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_tracing:
-	python -u examples/ex_tracing.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_tracing.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 ex_docker:
-	python -u examples/ex_docker.py --url ws://localhost:9000/ws --realm test1 --keyfile ${HOME}/.cbf/default.priv
+	python3 -u examples/ex_docker.py --url ws://localhost:9000/ws --realm ${realm} --keyfile ${HOME}/.cbf/default.priv
 
 
 #


### PR DESCRIPTION
Examples require python3, we were calling them with 'python' which in most Linux distro refers to python2.

Added some flexibility to Makefile, we can now pass custom realm from commandline, example:

`make ex_docker realm=iaa1`